### PR TITLE
Add check to ensure we have a valid property (i.e. is length 2, key/value) before adding

### DIFF
--- a/lib/src/gradle_properties.dart
+++ b/lib/src/gradle_properties.dart
@@ -46,9 +46,11 @@ class GradleProperties {
     try {
       final lines = file.readAsLinesSync();
       final props = {
-        for (final line in lines) line.split('=')[0]: line.split('=')[1]
+        for (final line in lines)
+          if (line.split('=').length == 2)
+            line.split('=')[0]: line.split('=')[1]
       };
-      return GradleProperties._(props, file);
+      return props.isEmpty ? null : GradleProperties._(props, file);
     } catch (error, stacktrace) {
       print(error);
       print(stacktrace);

--- a/test/test_data.properties
+++ b/test/test_data.properties
@@ -2,3 +2,4 @@ first_name=Birju
 last_name=Vachhani
 email=brvachhani@gmail.com
 age=24
+# This is a comment in gradle.properties and should not be considered a property


### PR DESCRIPTION
### Description of the Change
When reading a gradle.properties it may have a comment in it. Furthermore, if for any reason there isn't a key/value pair (i.e. a line with a <string>=<string> format) we should not attempt to add it to the map. Otherwise this will throw even on valid gradle.properties.

### Alternate Designs

Reuse as much as possible.

### Why Should This Be In Core?

This causes errors any time you try and load a file with a comment which means it's pretty unstable.

### Benefits

Can now support comments in gradle.properties.

### Possible Drawbacks

None noted.

### Verification Process

Updated test files to show problem and all tests still pass now that the code change has been made.

### Applicable Issues

None noted.
