### PR TITLE
Allow for empty lines in a gradle.properties file

### DIFF
--- a/lib/src/gradle_properties.dart
+++ b/lib/src/gradle_properties.dart
@@ -80,7 +80,7 @@ class GradleProperties {
 
     for (final (index, line) in lines.indexed) {
       // comment line, skip
-      if (line.startsWith('#')) continue;
+      if (line.startsWith('#') || line.isEmpty) continue;
 
       final tokens = line.split('=');
       if (tokens.length != 2) {

--- a/lib/src/gradle_properties.dart
+++ b/lib/src/gradle_properties.dart
@@ -73,7 +73,6 @@ class GradleProperties {
 
   static Map<String, String> _parse(String content) {
     content = content.trim();
-    if (content.isEmpty) throw ArgumentError('content cannot be empty');
 
     final lines = const LineSplitter().convert(content);
     final Map<String, String> props = {};

--- a/test/gradle_properties_test.dart
+++ b/test/gradle_properties_test.dart
@@ -41,7 +41,7 @@ void main() {
       final properties =
           await GradleProperties.fromFile(File('test/test_data.properties'));
       expect(properties, isNotNull);
-      expect(properties!.properties, hasLength(4));
+      expect(properties!.properties, hasLength(6));
     });
 
     test('load from map test', () async {

--- a/test/test_data.properties
+++ b/test/test_data.properties
@@ -3,3 +3,8 @@ last_name=Vachhani
 email=brvachhani@gmail.com
 age=24
 # This is a comment = in gradle.properties and should not be considered a property
+
+# empty lines should not throw and be skipped
+client_first=John
+
+client_last=Doe


### PR DESCRIPTION
### Description of the Change

gradle.properties should be allowed to have empty lines. This change will not consider empty lines as an error and will no longer throw an exception.

### Alternate Designs

We should also allow for users to have an empty file that they are trying to populate. Currently the code does not allow an empty file which isn't ideal, but has not been addressed here.

### Why Should This Be In Core?

Empty lines are commonly used in gradle.properties to help organize values.

### Benefits

Can now parse gradle.properties that have new lines/empty lines

### Possible Drawbacks

N/A

### Verification Process

All tests were updated and the gradle.properties file for testing includes empty lines.

### Applicable Issues

Can't handle empty gradlle.properties files.
